### PR TITLE
Add desktop file

### DIFF
--- a/nmcli_dmenu.desktop
+++ b/nmcli_dmenu.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Categories=Settings;Network;
+Name=nmcli_dmenu
+GenericName=Picture Viewer
+Exec=nmcli_dmenu
+Type=Application
+
+


### PR DESCRIPTION
In case dmenu is configured to use only applications that contain .desktop 
files, we need one for nmcli-dmenu as well, otherwise it will not be seen.
