### PR TITLE
list of ssids now show only the strongest of duplicate ssids

### DIFF
--- a/nmcli_dmenu
+++ b/nmcli_dmenu
@@ -46,8 +46,7 @@ def current_conns():
 
     """
     conns = ["nmcli", "-t", "-f", "name,type", "con", "list"]
-    return Popen(conns,
-                 stdout=PIPE).communicate()[0].decode().split('\n')
+    return Popen(conns, stdout=PIPE).communicate()[0].decode().split('\n')
 
 
 def current_ssids():
@@ -62,8 +61,25 @@ def current_ssids():
     res = Popen(scan, stdout=PIPE).communicate()[0].decode().split("\n")
     del res[-1]
     res = [i.rsplit(':', 1) for i in res]
+    res = unique_ssid(res)
     res = sorted(res, key=lambda x: x[1], reverse=True)
     return [i[0].replace("'", "") for i in res]
+
+def unique_ssid(conns):
+    """ Filters the list of ids, so that duplicate ids will only
+        show the one with the greatset strength
+    """
+    ssids = {}
+    for conn in conns:
+        ssid = conn[0]
+        strength = conn[1]
+        if ssid in ssids:
+            if ssids[ssid] < strength:
+                ssids[ssid] = strength
+        else:
+            ssids[ssid] = strength
+    conns = [[key,val] for (key,val) in ssids.items()]
+    return conns
 
 
 def vpn_connections(conns):


### PR DESCRIPTION
I modified the list function to filter duplicate ssids based on their strength,
so that the list would not be polluted with lots of different connections with the same name.
