### PR TITLE
Add rofi_highlight

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,410 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint.
+jobs=1
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=print-statement,parameter-unpacking,unpacking-in-except,old-raise-syntax,backtick,long-suffix,old-ne-operator,old-octal-literal,import-star-module-level,raw-checker-failed,bad-inline-option,locally-disabled,locally-enabled,file-ignored,suppressed-message,useless-suppression,deprecated-pragma,apply-builtin,basestring-builtin,buffer-builtin,cmp-builtin,coerce-builtin,execfile-builtin,file-builtin,long-builtin,raw_input-builtin,reduce-builtin,standarderror-builtin,unicode-builtin,xrange-builtin,coerce-method,delslice-method,getslice-method,setslice-method,no-absolute-import,old-division,dict-iter-method,dict-view-method,next-method-called,metaclass-assignment,indexing-exception,raising-string,reload-builtin,oct-method,hex-method,nonzero-method,cmp-method,input-builtin,round-builtin,intern-builtin,unichr-builtin,map-builtin-not-iterating,zip-builtin-not-iterating,range-builtin-not-iterating,filter-builtin-not-iterating,using-cmp-argument,eq-without-hash,div-method,idiv-method,rdiv-method,exception-message-attribute,invalid-str-codec,sys-max-int,bad-python3-import,deprecated-string-function,deprecated-str-translate-call
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio).You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+
+[SPELLING]
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX,TODO
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,_cb
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,future.builtins
+
+
+[BASIC]
+
+# Naming hint for argument names
+argument-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+# Regular expression matching correct argument names
+argument-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+# Naming hint for attribute names
+attr-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+# Regular expression matching correct attribute names
+attr-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# Naming hint for class attribute names
+class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Naming hint for class names
+class-name-hint=[A-Z_][a-zA-Z0-9]+$
+
+# Regular expression matching correct class names
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+# Naming hint for constant names
+const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Regular expression matching correct constant names
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming hint for function names
+function-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+# Regular expression matching correct function names
+function-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,Run,_
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Naming hint for inline iteration names
+inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Naming hint for method names
+method-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+# Regular expression matching correct method names
+method-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+# Naming hint for module names
+module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Regular expression matching correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+property-classes=abc.abstractproperty
+
+# Naming hint for variable names
+variable-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+# Regular expression matching correct variable names
+variable-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=80
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,dict-separator
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[IMPORTS]
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in a if statement
+max-bool-expr=5
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/config.ini.example
+++ b/config.ini.example
@@ -13,6 +13,7 @@ fn = -*-terminus-medium-*-*-*-16-*-*-*-*-*-*-*
 # m = number of monitor to display on
 # p = Custom Prompt for the networks menu
 # pinentry = Pinentry command
+# rofi_highlight = <True or False> # (Default: False) use rofi highlighting instead of '**'
 
 [editor]
 terminal = urxvtc

--- a/networkmanager_dmenu
+++ b/networkmanager_dmenu
@@ -90,7 +90,8 @@ def dmenu_cmd(num_lines, prompt="Networks", active_lines=None):
             del args_dict["pinentry"]
         if "rofi_highlight" in args_dict:
             if active_lines:
-                dmenu_args.extend(["-a", ",".join([str(num) for num in active_lines])])
+                dmenu_args.extend(["-a", ",".join([str(num)
+                                                   for num in active_lines])])
             del args_dict["rofi_highlight"]
         extras = (["-" + str(k), str(v)] for (k, v) in args_dict.items())
         res = [dmenu_command, "-p", str(prompt)]
@@ -173,7 +174,7 @@ class Action(object):
                  f,
                  args=None,
                  active=False,
-                 ):
+                ):
         self.name = name
         self.f = f
         self.is_active = active
@@ -240,7 +241,8 @@ def create_ap_actions(aps, active_ap, active_connection, adapter):
                                                     max_len_sec, bars)
         if is_active:
             ap_actions.append(Action(action_name, process_ap,
-                                     [active_connection, True, adapter], active=True))
+                                     [active_connection, True, adapter],
+                                     active=True))
         else:
             ap_actions.append(Action(action_name, process_ap,
                                      [ap, False, adapter]))
@@ -310,11 +312,14 @@ def get_selection(client, aps, vpns, gsms, others):
     if rofi_highlight:
         inp = [str(action) for action in all_actions]
     else:
-        inp = [('** ' if action.is_active else '   ') + str(action) for action in all_actions]
-    active_lines = [index for index, action in enumerate(all_actions) if action.is_active]
+        inp = [('** ' if action.is_active else '   ') + str(action)
+               for action in all_actions]
+    active_lines = [index for index, action in enumerate(all_actions)
+                    if action.is_active]
 
     inp_bytes = "\n".join([str(i) for i in inp]).encode(ENC)
-    sel = Popen(dmenu_cmd(len(inp), active_lines=active_lines), stdin=PIPE, stdout=PIPE,
+    command = dmenu_cmd(len(inp), active_lines=active_lines)
+    sel = Popen(command, stdin=PIPE, stdout=PIPE,
                 env=ENV).communicate(input=inp_bytes)[0].decode(ENC)
 
     if not sel.rstrip():
@@ -322,11 +327,14 @@ def get_selection(client, aps, vpns, gsms, others):
 
     if not rofi_highlight:
         action = [i for i in aps + vpns + gsms + others
-                  if prepend_marker_to_active_action(i) == str(sel.rstrip("\n"))]
+                  if ((str(i) == str(sel.rstrip("\n")) and not i.is_active()) or
+                      ('** ' + str(i) == str(sel.rstrip('\n'))
+                       and i.is_active()))]
     else:
         action = [i for i in aps + vpns + gsms + others
                   if str(i) == sel.rstrip("\n")]
-    assert len(action) == 1, "Selection was ambiguous: '{}'".format(str(sel.rstrip("\n")))
+    assert len(action) == 1, \
+            "Selection was ambiguous: '{}'".format(str(sel.rstrip("\n")))
     return action[0]
 
 

--- a/networkmanager_dmenu
+++ b/networkmanager_dmenu
@@ -39,7 +39,7 @@ loop = GLib.MainLoop()
 conns = client.get_connections()
 
 
-def dmenu_cmd(num_lines, prompt="Networks"):
+def dmenu_cmd(num_lines, prompt="Networks", active_lines=None):
     """Parse config.ini if it exists and add options to the dmenu command
 
     Args: args - num_lines: number of lines to display
@@ -88,6 +88,10 @@ def dmenu_cmd(num_lines, prompt="Networks"):
             lines = "{} {}".format(lines, num_lines)
         if "pinentry" in args_dict:
             del args_dict["pinentry"]
+        if "rofi_highlight" in args_dict:
+            if active_lines:
+                dmenu_args.extend(["-a", ",".join([str(num) for num in active_lines])])
+            del args_dict["rofi_highlight"]
         extras = (["-" + str(k), str(v)] for (k, v) in args_dict.items())
         res = [dmenu_command, "-p", str(prompt)]
         res.extend(dmenu_args)
@@ -168,9 +172,11 @@ class Action(object):
                  name,
                  f,
                  args=None,
+                 active=False,
                  ):
         self.name = name
         self.f = f
+        self.is_active = active
         if args is None:
             self.args = None
         elif isinstance(args, list):
@@ -230,13 +236,11 @@ def create_ap_actions(aps, active_ap, active_connection, adapter):
     for ap, name, sec in zip(aps, names, secs):
         bars = NM.utils_wifi_strength_bars(ap.get_strength())
         is_active = ap.get_bssid() == active_ap_bssid
-        active_flag = "**" if is_active else "  "
-        action_name = "{} {:<{}s}  {:<{}s}  {}".format(active_flag, name,
-                                                       max_len_name, sec,
-                                                       max_len_sec, bars)
+        action_name = "{:<{}s}  {:<{}s}  {}".format(name, max_len_name, sec,
+                                                    max_len_sec, bars)
         if is_active:
             ap_actions.append(Action(action_name, process_ap,
-                                     [active_connection, True, adapter]))
+                                     [active_connection, True, adapter], active=True))
         else:
             ap_actions.append(Action(action_name, process_ap,
                                      [ap, False, adapter]))
@@ -260,8 +264,7 @@ def _create_vpngsm_actions(cons, active_cons, label):
     actions = []
     for con in cons:
         is_active = con.get_id() in active_con_ids
-        active_flag = "**" if is_active else "  "
-        action_name = "{} {}:{}".format(active_flag, con.get_id(), label)
+        action_name = "{}:{}".format(con.get_id(), label)
         if is_active:
             active_connection = [a for a in active_cons
                                  if a.get_id() == con.get_id()]
@@ -271,7 +274,7 @@ def _create_vpngsm_actions(cons, active_cons, label):
             active_connection = active_connection[0]
 
             actions.append(Action(action_name, process_vpngsm,
-                                  [active_connection, False]))
+                                  [active_connection, False], active=True))
         else:
             actions.append(Action(action_name, process_vpngsm,
                                   [con, True]))
@@ -287,30 +290,43 @@ def get_selection(client, aps, vpns, gsms, others):
                  gsms: list of Actions
                  others: list of Actions
     """
-    formated_aps = [str(ap) for ap in aps]
-    formated_vpns = [str(vpn) for vpn in vpns]
-    formated_gsms = [str(gsm) for gsm in gsms]
-    formated_others = [str(other) for other in others]
+
+    conf = configparser.ConfigParser()
+    conf.read(expanduser("~/.config/networkmanager-dmenu/config.ini"))
+
+    try:
+        rofi_highlight = conf.getboolean('dmenu', 'rofi_highlight')
+    except (configparser.NoOptionError, configparser.NoSectionError):
+        rofi_highlight = False
 
     inp = []
-    if formated_aps:
-        inp += formated_aps + [""]
-    if vpns:
-        inp += formated_vpns + [""]
-    if gsms:
-        inp += formated_gsms + [""]
-    inp += formated_others
+    empty_action = [Action('', None)]
+    all_actions = []
+    all_actions += aps + empty_action if aps else []
+    all_actions += vpns + empty_action if vpns else []
+    all_actions += gsms + empty_action if gsms else []
+    all_actions += others
+
+    if rofi_highlight:
+        inp = [str(action) for action in all_actions]
+    else:
+        inp = [('** ' if action.is_active else '   ') + str(action) for action in all_actions]
+    active_lines = [index for index, action in enumerate(all_actions) if action.is_active]
 
     inp_bytes = "\n".join([str(i) for i in inp]).encode(ENC)
-    sel = Popen(dmenu_cmd(len(inp)), stdin=PIPE, stdout=PIPE,
+    sel = Popen(dmenu_cmd(len(inp), active_lines=active_lines), stdin=PIPE, stdout=PIPE,
                 env=ENV).communicate(input=inp_bytes)[0].decode(ENC)
 
     if not sel.rstrip():
         sys.exit()
 
-    action = [i for i in aps + vpns + gsms + others
-              if str(i) == sel.rstrip("\n")]
-    assert len(action) == 1, "Selection was ambiguous: {}".format(str(sel))
+    if not rofi_highlight:
+        action = [i for i in aps + vpns + gsms + others
+                  if prepend_marker_to_active_action(i) == str(sel.rstrip("\n"))]
+    else:
+        action = [i for i in aps + vpns + gsms + others
+                  if str(i) == sel.rstrip("\n")]
+    assert len(action) == 1, "Selection was ambiguous: '{}'".format(str(sel.rstrip("\n")))
     return action[0]
 
 

--- a/networkmanager_dmenu
+++ b/networkmanager_dmenu
@@ -12,18 +12,18 @@ Add dmenu formatting options and default terminal if desired to
 ~/.config/networkmanager-dmenu/config.ini
 
 """
-import gi
 import itertools
 import locale
 import os
+from os.path import expanduser
 import shlex
 import sys
 import uuid
-from os.path import expanduser
 from subprocess import Popen, PIPE
 
+import gi
 gi.require_version('NM', '1.0')
-from gi.repository import GLib, NM
+from gi.repository import GLib, NM # pylint: disable=wrong-import-position
 
 try:
     import configparser as configparser
@@ -500,7 +500,7 @@ def verify_conn(client, result, data):
         conn.verify_secrets()
         data.verify()
         data.verify_secrets()
-    except GLib.Error:
+    except GLib.Error: # pylint: disable=catching-non-exception
         conn.delete()
     finally:
         loop.quit()


### PR DESCRIPTION
This adds the ability to use rofi's highlighting capabilities, that
were introduced in rofi 0.15.4. It has to be enabled by the user.
So existing users, do not see a change in behaviour. If it is enabled,
the active connections are no longer marked with '**' in the beginning,
but highlighted by rofi (in a color depending on the user's
configuration).

In this example, the VPN 'DE - Frankfurt' is active, so it is highlighted by rofi:
![nm1](https://cloud.githubusercontent.com/assets/3579374/24589544/83847cc6-17dc-11e7-912e-e7f2371e9ee8.png)

I am not quite sure, which branch I should base this pull request on, master or develop?