### PR TITLE
Any of dmenu argument can be passed.

### DIFF
--- a/networkmanager_dmenu
+++ b/networkmanager_dmenu
@@ -58,7 +58,7 @@ def dmenu_cmd(num_lines, prompt="Networks", active_lines=None):  # pylint: disab
     except configparser.NoSectionError:
         conf = False
     if not conf:
-        res = [dmenu_command, "-i", "-l", str(num_lines), "-p", str(prompt)]
+        res = [dmenu_command, "-i", "-l", str(num_lines), "-p", str(prompt), "-b"]
     else:
         args_dict = dict(args)
         dmenu_args = []

--- a/networkmanager_dmenu
+++ b/networkmanager_dmenu
@@ -58,7 +58,7 @@ def dmenu_cmd(num_lines, prompt="Networks", active_lines=None):  # pylint: disab
     except configparser.NoSectionError:
         conf = False
     if not conf:
-        res = [dmenu_command, "-i", "-l", str(num_lines), "-p", str(prompt), "-b"]
+        res = [dmenu_command, "-i", "-l", str(num_lines), "-p", str(prompt)]
     else:
         args_dict = dict(args)
         dmenu_args = []
@@ -104,6 +104,7 @@ def dmenu_cmd(num_lines, prompt="Networks", active_lines=None):  # pylint: disab
         res.extend(dmenu_args)
         res += list(itertools.chain.from_iterable(extras))
         res[1:1] = lines.split()
+    res.extend(sys.argv[1:])
     return res
 
 


### PR DESCRIPTION
Maybe it is not safe, or even stupid, but this is, I think, a good way to be able to put it into other scripts and customize appearance. When I did this, I wanted to write `exec networkmanager_dmenu -b` into my i3-config file, but i couldn't. and now i can:-)