### PR TITLE
Allow dmenu option override for passphrase entry.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,7 @@ Installation
 
 - Set your dmenu_command in config.ini if it's not 'dmenu' (for example dmenu_run or rofi). The alternate command should still respect the -l, -p and -i flags.
 - To customize dmenu appearance, copy config.ini.example to ~/.config/networkmanager-dmenu/config.ini and edit.
+- If using dmenu for passphrase entry (pinentry not set), dmenu options in the [dmenu_passphrase] section of config.ini will override those in [dmenu] so you can, for example, set the normal foreground and background colors to be the same to obscure the passphrase.
 - Set default terminal (xterm, urxvtc, etc.) command in config.ini if desired.
 - If using Rofi, you can try some of the command line options in config.ini or set them using the `dmenu_command` setting, but I haven't tested most of them so I'd suggest configuring via .Xresources where possible. 
 - Copy script somewhere in $PATH

--- a/config.ini.example
+++ b/config.ini.example
@@ -15,6 +15,11 @@ fn = -*-terminus-medium-*-*-*-16-*-*-*-*-*-*-*
 # pinentry = Pinentry command
 # rofi_highlight = <True or False> # (Default: False) use rofi highlighting instead of '**'
 
+# # override normal foreground and background colors to obscure passphrase entry
+# [dmenu_passphrase]
+# nf = #222222
+# nb = #222222
+
 [editor]
 terminal = urxvtc
 gui_if_available = True

--- a/networkmanager_dmenu
+++ b/networkmanager_dmenu
@@ -41,7 +41,7 @@ CONNS = CLIENT.get_connections()
 if sys.version_info.major < 3:
     str = unicode
 
-def dmenu_cmd(num_lines, prompt="Networks", active_lines=None):  # pylint: disable=too-many-branches
+def dmenu_cmd(num_lines, prompt="Networks", active_lines=None, passphrase_entry=False):  # pylint: disable=too-many-branches
     """Parse config.ini if it exists and add options to the dmenu command
 
     Args: args - num_lines: number of lines to display
@@ -99,6 +99,13 @@ def dmenu_cmd(num_lines, prompt="Networks", active_lines=None):  # pylint: disab
             if active_lines:
                 dmenu_args.extend(["-a", ",".join([str(num)
                                                    for num in active_lines])])
+        if passphrase_entry:
+            try:
+                args = conf.items('dmenu_passphrase')
+            except configparser.NoSectionError:
+                conf = False
+            if conf:
+                args_dict.update(args)
         extras = (["-" + str(k), str(v)] for (k, v) in args_dict.items())
         res = [dmenu_command, "-p", str(prompt)]
         res.extend(dmenu_args)
@@ -438,7 +445,7 @@ def get_passphrase():
                 pin = res.split("D ")[1]
         return pin
     else:
-        return Popen(dmenu_cmd(0, "Passphrase"),
+        return Popen(dmenu_cmd(0, "Passphrase", passphrase_entry=True),
                      stdin=PIPE, stdout=PIPE).communicate()[0].decode(ENC)
 
 


### PR DESCRIPTION
Currently, passphrases are visible when using dmenu to enter them.  This adds the ability to set dmenu options specifically for the passphrase entry case, the most obvious use being to set the normal foreground and background to the same color to obscure the passphrase.