### PR TITLE
Fix AttributeError in create_gsm_actions()

### DIFF
--- a/networkmanager_dmenu
+++ b/networkmanager_dmenu
@@ -285,6 +285,7 @@ def create_gsm_actions(gsms, active):
     """Create the list of strings to display with associated function
     (activate/deactivate) GSM connections."""
     active_gsms = [i for i in active if
+                   i.get_connection() is not None and
                    i.get_connection().is_type(NM.SETTING_GSM_SETTING_NAME)]
     return _create_vpngsm_actions(gsms, active_gsms, "GSM")
 


### PR DESCRIPTION
The following traceback intermittently shows up, which this change fixes:

```
➔  dex /usr/share/applications/networkmanager_dmenu.desktop

Traceback (most recent call last):
  File "/usr/bin/networkmanager_dmenu", line 612, in <module>
    run()
  File "/usr/bin/networkmanager_dmenu", line 603, in run
    gsm_actions = create_gsm_actions(gsms, active)
  File "/usr/bin/networkmanager_dmenu", line 288, in create_gsm_actions
    i.get_connection().is_type(NM.SETTING_GSM_SETTING_NAME)]
AttributeError: 'NoneType' object has no attribute 'is_type'
```