### PR TITLE
Also control Ethernet and static IP connections.

### DIFF
--- a/networkmanager_dmenu
+++ b/networkmanager_dmenu
@@ -300,6 +300,15 @@ def create_vpn_actions(vpns, active):
     return _create_vpngsm_actions(vpns, active_vpns, "VPN")
 
 
+def create_eth_actions(eths, active):
+    """Create the list of strings to display with associated function
+    (activate/deactivate) for Ethernet connections.
+
+    """
+    active_eths = [i for i in active if 'ethernet' in i.get_connection_type()]
+    return _create_vpngsm_actions(eths, active_eths, "Eth")
+
+
 def create_gsm_actions(gsms, active):
     """Create the list of strings to display with associated function
     (activate/deactivate) GSM connections."""
@@ -349,11 +358,12 @@ def create_wwan_actions(client):
     return [Action("{} WWAN".format(wwan_action), toggle_wwan, not wwan_enabled)]
 
 
-def get_selection(aps, vpns, gsms, blues, wwan, others):
+def get_selection(eths, aps, vpns, gsms, blues, wwan, others):
     """Combine the arg lists and send to dmenu for selection.
     Also executes the associated action.
 
-    Args: args - aps: list of Actions
+    Args: args - eths: list of Actions
+                 aps: list of Actions
                  vpns: list of Actions
                  gsms: list of Actions
                  blues: list of Actions
@@ -369,6 +379,7 @@ def get_selection(aps, vpns, gsms, blues, wwan, others):
     inp = []
     empty_action = [Action('', None)]
     all_actions = []
+    all_actions += eths + empty_action if eths else []
     all_actions += aps + empty_action if aps else []
     all_actions += vpns + empty_action if vpns else []
     all_actions += gsms + empty_action if (gsms and wwan) else []
@@ -393,13 +404,13 @@ def get_selection(aps, vpns, gsms, blues, wwan, others):
         sys.exit()
 
     if rofi_highlight is False:
-        action = [i for i in aps + vpns + gsms + blues + wwan + others
+        action = [i for i in eths + aps + vpns + gsms + blues + wwan + others
                   if ((str(i).strip() == str(sel.strip())
                        and not i.is_active) or
                       ('** ' + str(i) == str(sel.rstrip('\n'))
                        and i.is_active))]
     else:
-        action = [i for i in aps + vpns + gsms + blues + wwan + others
+        action = [i for i in eths + aps + vpns + gsms + blues + wwan + others
                   if str(i).strip() == sel.strip()]
     assert len(action) == 1, \
             u"Selection was ambiguous: '{}'".format(str(sel.strip()))
@@ -639,9 +650,11 @@ def run():
         ap_actions = []
 
     vpns = [i for i in CONNS if i.is_type(NM.SETTING_VPN_SETTING_NAME)]
+    eths = [i for i in CONNS if i.is_type(NM.SETTING_WIRED_SETTING_NAME)]
     blues = [i for i in CONNS if i.is_type(NM.SETTING_BLUETOOTH_SETTING_NAME)]
 
     vpn_actions = create_vpn_actions(vpns, active)
+    eth_actions = create_eth_actions(eths, active)
     blue_actions = create_blue_actions(blues, active)
     other_actions = create_other_actions(CLIENT)
     wwan_installed = is_modemmanager_installed()
@@ -653,7 +666,7 @@ def run():
         gsm_actions = []
         wwan_actions = []
 
-    sel = get_selection(ap_actions, vpn_actions, gsm_actions,
+    sel = get_selection(eth_actions, ap_actions, vpn_actions, gsm_actions,
                         blue_actions, wwan_actions, other_actions)
     sel()
 


### PR DESCRIPTION
## Rant for empathy
Boy, that NM API is not easy to find. I think this is pretty effective though.

## Description
The nm-applet also shows Ethernet connections, if you have a computer with Ethernet. I use this a lot for applying different DHCP options or even static IPs to some networks that I frequently use. Allowing me to connect or disconnect them with dmenu is going to save a lot of time. Maybe there are more people like me? I hope you don't mind me putting the Ethernet at the top. I did that because that's what nm-applet did.

## Verification
On my machine (ubuntu 16.04), the Ethernet, VPN and WiFi stuff all shows up in a similar list to when I use nm-applet. Disabling and Enabling other Ethernet Connections were all tested and worked.