### PR TITLE
Use different icon for active connections

### DIFF
--- a/networkmanager_dmenu
+++ b/networkmanager_dmenu
@@ -415,7 +415,7 @@ def get_selection(eths, aps, vpns, wgs, gsms, blues, wwan, others):
     if rofi_highlight is True:
         inp = [str(action) for action in all_actions]
     else:
-        inp = [('** ' if action.is_active else '   ') + str(action)
+        inp = [('== ' if action.is_active else '   ') + str(action)
                for action in all_actions]
     active_lines = [index for index, action in enumerate(all_actions)
                     if action.is_active]


### PR DESCRIPTION
I have many connection profiles, and sometimes I just want to quickly locate the active connection (for example, to disconnect from VPN).

Right now, active connections are marked with `**`. Instead of remembering the connection name, I'd like to just type this prefix in the filter box. However, `**` symbol is _also_ used for connection quality, so by typing `**` I don't filter anything and I still have a lot of connections visible.

With this PR I change the active connections marker to `==`, which is unique, and so now it's easy to jump directly to the active connection, by typing `==` in the filter box.