### PR TITLE
Added support for dmenu password patch through configuration option

### DIFF
--- a/config.ini.example
+++ b/config.ini.example
@@ -21,11 +21,13 @@ fn = SourceCodePro-11
 # list_saved = <True or False> # (Default: False) list saved connections
 
 # [dmenu_passphrase]
-# # override normal foreground and background colors (dmenu) or use the
+# # override normal foreground and background colors or use
+# https://tools.suckless.org/dmenu/patches/password/ (dmenu); use the
 # # -password option (rofi) to obscure passphrase entry
 # nf = #222222
 # nb = #222222
 # rofi_obscure = <True or False> (Default: True) Obscure passwords when typing
+# dmenu_password = <True or False> (Default: False) Use the -P option for dmenu (you need the appropriate dmenu patch!)
 
 # [editor]
 # terminal = <name of terminal program>

--- a/networkmanager_dmenu
+++ b/networkmanager_dmenu
@@ -103,6 +103,11 @@ def dmenu_cmd(num_lines, prompt="Networks", active_lines=None):  # pylint: disab
             del args_dict["rofi_obscure"]
         if rofi_obscure is True and "rofi" in dmenu_command:
             dmenu_args.extend(["-password"])
+        dmenu_password = CONF.getboolean('dmenu_passphrase', 'dmenu_password', fallback=True)
+        if CONF.has_option('dmenu_passphrase', 'dmenu_password'):
+            del args_dict["dmenu_password"]
+        if dmenu_password is True:
+            dmenu_args.extend(["-P"])
     extras = (["-" + str(k), str(v)] for (k, v) in args_dict.items())
     res = [dmenu_command, "-p", str(prompt)]
     res.extend(dmenu_args)


### PR DESCRIPTION
This PR adds support for [this](https://github.com/BachoSeven/networkmanager-dmenu) patch; which provides the `-P` dmenu option which is, in my opinion, a much cleaner solution for hiding the password