### PR TITLE
Added gnome-control-center support for 'Launch Connection Manager'

### DIFF
--- a/networkmanager_dmenu
+++ b/networkmanager_dmenu
@@ -550,9 +550,12 @@ def launch_connection_editor():
     gui_if_available = CONF.getboolean("editor", "gui_if_available", fallback=True)
     if gui_if_available is True:
         try:
-            Popen(["nm-connection-editor"]).communicate()
+            Popen(["gnome-control-center", "network"]).communicate()
         except OSError:
-            Popen([terminal, "-e", "nmtui"]).communicate()
+            try:
+                Popen(["nm-connection-editor"]).communicate()
+            except OSError:
+                Popen([terminal, "-e", "nmtui"]).communicate()
     else:
         Popen([terminal, "-e", "nmtui"]).communicate()
 


### PR DESCRIPTION
First try to open gnome-control-center's network panel before the nm-connection-editor. If gnome-control-center is not installed it will not be used, and will fall back to nm-connection-editor.