### PR TITLE
Avoid unneeded functools

### DIFF
--- a/networkmanager_dmenu
+++ b/networkmanager_dmenu
@@ -20,7 +20,6 @@ from os.path import expanduser
 import shlex
 import sys
 import uuid
-import functools
 from subprocess import Popen, PIPE
 
 import gi
@@ -802,8 +801,7 @@ def run():
     if list_saved:
         saved_actions = create_saved_actions(saved_cons)
     else:
-        saved_actions = [Action("Saved connections",
-                                functools.partial(prompt_saved, saved_cons))]
+        saved_actions = [Action("Saved connections", prompt_saved, [saved_cons])]
 
     actions = combine_actions(eth_actions, ap_actions, vpn_actions, wg_actions,
                               gsm_actions, blue_actions, wwan_actions,


### PR DESCRIPTION
Follow-up to #88

Like you said in https://github.com/firecat53/networkmanager-dmenu/pull/88#issuecomment-691177690 using `functools` isn't needed here - I didn't look closely at the `Action` class and didn't notice it already has a way to pass arguments to the underlying function.

To expand on what `functools.partial` does: It essentially "binds" the given arguments to the given function, returning a new function which can then be called without arguments. The concept is usually known as [currying](https://en.wikipedia.org/wiki/Currying) or "partial application". Since we already have a much simpler way to pass arguments, it's indeed not needed at all here.