### PR TITLE
Add toggle for Bluetooth

### DIFF
--- a/networkmanager_dmenu
+++ b/networkmanager_dmenu
@@ -12,6 +12,8 @@ Add dmenu formatting options and default terminal if desired to
 ~/.config/networkmanager-dmenu/config.ini
 
 """
+import pathlib
+import struct
 import configparser
 import itertools
 import locale
@@ -151,20 +153,40 @@ def is_modemmanager_installed():
         return True
 
 
+def bluetooth_get_enabled():
+    """Check if bluetooth is enabled via rfkill.
+
+    Returns None if no bluetooth device was found.
+    """
+    # See https://www.kernel.org/doc/Documentation/ABI/stable/sysfs-class-rfkill
+    for path in pathlib.Path('/sys/class/rfkill/').glob('rfkill*'):
+        if (path / 'type').read_text().strip() == 'bluetooth':
+            return (path / 'soft').read_text().strip() == '0'
+    return None
+
+
 def create_other_actions(client):
     """Return list of other actions that can be taken
 
     """
     networking_enabled = client.networking_get_enabled()
     networking_action = "Disable" if networking_enabled else "Enable"
+
     wifi_enabled = client.wireless_get_enabled()
     wifi_action = "Disable" if wifi_enabled else "Enable"
+
+    bluetooth_enabled = bluetooth_get_enabled()
+    bluetooth_action = "Disable" if bluetooth_enabled else "Enable"
+
     actions = [Action("{} Wifi".format(wifi_action), toggle_wifi,
                       not wifi_enabled),
                Action("{} Networking".format(networking_action),
-                      toggle_networking, not networking_enabled),
-               Action("Launch Connection Manager", launch_connection_editor),
-               Action("Delete a Connection", delete_connection)]
+                      toggle_networking, not networking_enabled)]
+    if bluetooth_enabled is not None:
+        actions.append(Action("{} Bluetooth".format(bluetooth_action),
+                       toggle_bluetooth, not bluetooth_enabled))
+    actions += [Action("Launch Connection Manager", launch_connection_editor),
+                Action("Delete a Connection", delete_connection)]
     if wifi_enabled:
         actions.append(Action("Rescan Wifi Networks", rescan_wifi))
     return actions
@@ -550,6 +572,29 @@ def toggle_wwan(enable):
         # Workaround for older versions of python-gobject
         CLIENT.wwan_set_enabled(enable)
     notify("Wwan {}".format("enabled" if enable is True else "disabled"))
+
+
+def toggle_bluetooth(enable):
+    """Enable/disable Bluetooth
+
+    Args: enable - boolean
+    """
+    # References:
+    # https://github.com/blueman-project/blueman/blob/master/blueman/plugins/mechanism/RfKill.py
+    # https://www.kernel.org/doc/html/latest/driver-api/rfkill.html
+    # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/include/uapi/linux/rfkill.h?h=v5.8.9
+    TYPE_BLUETOOTH = 2
+    OP_CHANGE_ALL = 3
+    idx = 0
+    soft_state = 0 if enable else 1
+    hard_state = 0
+
+    data = struct.pack("IBBBB", idx, TYPE_BLUETOOTH, OP_CHANGE_ALL,
+                       soft_state, hard_state)
+    with open('/dev/rfkill', 'r+b', buffering=0) as f:
+        f.write(data)
+
+    notify("Bluetooth {}".format("enabled" if enable else "disabled"))
 
 
 def launch_connection_editor():

--- a/networkmanager_dmenu
+++ b/networkmanager_dmenu
@@ -203,7 +203,7 @@ def rescan_wifi():
                 LOOP.run()
             except gi.repository.GLib.Error as err:
                 # Too frequent rescan error
-                notify("Wifi rescan failed")
+                notify("Wifi rescan failed", urgency="critical")
                 if not err.code == 6:  # pylint: disable=no-member
                     raise err
 
@@ -215,7 +215,7 @@ def rescan_cb(dev, res, data):
     if dev.request_scan_finish(res) is True:
         notify("Wifi scan complete")
     else:
-        notify("Wifi scan failed")
+        notify("Wifi scan failed", urgency="critical")
     LOOP.quit()
 
 
@@ -321,7 +321,8 @@ def activate_cb(dev, res, data):
     if conn is not None:
         notify("Activated {}".format(conn.get_id()))
     else:
-        notify("Problem activating {}".format(data.get_id()))
+        notify("Problem activating {}".format(data.get_id()),
+                urgency="critical")
     LOOP.quit()
 
 
@@ -332,7 +333,8 @@ def deactivate_cb(dev, res, data):
     if dev.deactivate_connection_finish(res) is True:
         notify("Deactivated {}".format(data.get_id()))
     else:
-        notify("Problem deactivating {}".format(data.get_id()))
+        notify("Problem deactivating {}".format(data.get_id()),
+                urgency="critical")
     LOOP.quit()
 
 
@@ -661,7 +663,7 @@ def delete_cb(dev, res, data):
     if dev.delete_finish(res) is True:
         notify("Deleted {}".format(dev.get_id()))
     else:
-        notify("Problem deleting {}".format(dev.get_id()))
+        notify("Problem deleting {}".format(dev.get_id()), urgency="critical")
     LOOP.quit()
 
 
@@ -745,7 +747,8 @@ def verify_conn(client, result, data):
         notify("Added {}".format(conn.get_id()))
     except GLib.Error:  # pylint: disable=catching-non-exception
         try:
-            notify("Connection to {} failed".format(conn.get_id()))
+            notify("Connection to {} failed".format(conn.get_id()),
+                    urgency="critical")
             conn.delete_async(None, None, None)
         except UnboundLocalError:
             pass

--- a/networkmanager_dmenu
+++ b/networkmanager_dmenu
@@ -797,14 +797,16 @@ def create_ap_list(adapter, active_connections):
     return aps, active_ap, active_ap_con, adapter
 
 
-def notify(string):
+def notify(message, details=None, urgency="low"):
     """Use notify-send if available for notifications
 
     """
+    args = ["-u", urgency, message]
+    if details is not None:
+        args.append(details)
+
     try:
-        Popen(["notify-send",
-               "-u", "low",
-               "{}".format(string)],
+        Popen(["notify-send"] + args,
               stdout=PIPE, stderr=PIPE).communicate()
     except FileNotFoundError:
         pass

--- a/networkmanager_dmenu
+++ b/networkmanager_dmenu
@@ -593,10 +593,16 @@ def toggle_bluetooth(enable):
 
     data = struct.pack("IBBBB", idx, TYPE_BLUETOOTH, OP_CHANGE_ALL,
                        soft_state, hard_state)
-    with open('/dev/rfkill', 'r+b', buffering=0) as f:
-        f.write(data)
 
-    notify("Bluetooth {}".format("enabled" if enable else "disabled"))
+    try:
+        with open('/dev/rfkill', 'r+b', buffering=0) as f:
+            f.write(data)
+    except PermissionError:
+        notify("Lacking permission to write to /dev/rfkill.",
+               "Maybe you need to add your user to the 'rfkill' group?",
+               urgency="critical")
+    else:
+        notify("Bluetooth {}".format("enabled" if enable else "disabled"))
 
 
 def launch_connection_editor():


### PR DESCRIPTION
I use NetworkManager for Bluetooth tethering with Android - for some reason, NetworkManager itself doesn't provide any way to disable/enable Bluetooth radios, even though it can connect to them just fine, if they are enabled.

Thus, I always need to first use rfkill or blueman to enable Bluetooth before I can connect with networkmanager_dmenu. With this change, I can do it all right from rofi.

---

Admittedly, this is a bit of a hack. I first thought I'd use the commandline output of the `rfkill` tool first, but its output seems to have changed a bit between different `util-linux` versions. It does offer JSON output since utils-linux v2.31.1 (December 2017) which does seem to be part of Debian Buster (the current stable) and Ubuntu 18.04 LTS, but not e.g. Ubuntu 16.04 LTS which is still supported until 2021.

Thus, I decided to use the kernel interfaces directly, which is a bit more stable and avoids having to spawn a subprocess which essentially [does the same in C](https://github.com/karelzak/util-linux/blob/master/sys-utils/rfkill.c) anyways.

I'm not aware of a way to do the same thing in a more high-level way (e.g. via Networkmanager/DBus), so that's what I ended up with looking at the Blueman code. Blueman *does* actually use DBus if [ConnMan](https://01.org/connman) is available, but since that'd probably conflict with NetworkManager I doubt anyone using `networkmanager_dmenu` will have it running.