### PR TITLE
Improve notifications

### DIFF
--- a/networkmanager_dmenu
+++ b/networkmanager_dmenu
@@ -837,7 +837,7 @@ def notify(message, details=None, urgency="low"):
     """Use notify-send if available for notifications
 
     """
-    args = ["-u", urgency, "Network", message]
+    args = ["-u", urgency, "-a", "networkmanager-dmenu", "Network", message]
     if details is not None:
         args.append(details)
 

--- a/networkmanager_dmenu
+++ b/networkmanager_dmenu
@@ -837,7 +837,7 @@ def notify(message, details=None, urgency="low"):
     """Use notify-send if available for notifications
 
     """
-    args = ["-u", urgency, message]
+    args = ["-u", urgency, "Network", message]
     if details is not None:
         args.append(details)
 


### PR DESCRIPTION
It will be a better idea to adjust the message to have a different title per notification than just a generic 'Network' but this is still better than having 'notify-send' (or 'networkmanager-dmenu' with this PR) show up as the notification title. 