### PR TITLE
Fix dmenu password patch check

### DIFF
--- a/networkmanager_dmenu
+++ b/networkmanager_dmenu
@@ -88,7 +88,7 @@ def dmenu_cmd(num_lines, prompt="Networks", active_lines=None):  # pylint: disab
         obscure_color = CONF.get('dmenu_passphrase', 'obscure_color', fallback='#222222')
         try:
             # Check for dmenu password patch
-            dm_patch = b'bfivP' in sprun(["dmenu", "-h"], check=False, capture_output=True).stderr
+            dm_patch = b'P' in sprun(["dmenu", "-h"], check=False, capture_output=True).stderr
         except FileNotFoundError:
             dm_patch = False
         dmenu = ["-P"] if dm_patch else ["-nb", obscure_color, "-nf", obscure_color]


### PR DESCRIPTION
Hi, I noticed that since I added another patch to my dmenu which changes the `dmenu -h` output the check for password patch was broken; I think checking for a uppercase `P` is enough, since the help output is all in lowecase otherwise.

For reference, this is my `dmenu -h`:

``` sh
usage: dmenu [-bfirPv] [-l lines] [-p prompt] [-fn font] [-m monitor]
             [-h height]
             [-nb color] [-nf color] [-sb color] [-sf color]
             [-nhb color] [-nhf color] [-shb color] [-shf color] [-w windowid]
```