### PR TITLE
Provide empty input to passphrase dmenu command

### DIFF
--- a/networkmanager_dmenu
+++ b/networkmanager_dmenu
@@ -666,6 +666,7 @@ def get_passphrase():
                 pin = res.split("D ")[1]
         return pin
     return subprocess.run(dmenu_cmd(0, "Passphrase"),
+                          stdin=subprocess.DEVNULL,
                           capture_output=True,
                           check=False,
                           encoding=ENC).stdout


### PR DESCRIPTION
I noticed that the passphrase input had stopped working while using bemenu. The issue occurs when dmenu_cmd is run to prompt for the passphrase - nothing is provided on the subprocess stdin. Bemenu will hang indefinitely waiting for input.

This patch simply sends an empty string on stdin to the dmenu command during the passphrase prompt.