### PR TITLE
Add a hint to check if NetworkManager is running

### DIFF
--- a/networkmanager_dmenu
+++ b/networkmanager_dmenu
@@ -862,6 +862,10 @@ def notify(message, details=None, urgency="low"):
 
 def run():  # pylint: disable=too-many-locals
     """Main script entrypoint"""
+    stat = subprocess.check_output(
+        "ps aux | grep /usr/bin/NetworkManager | wc -l", shell=True)
+    if int(stat) != 3:
+        print("WARNING: NetworkManager don't seems to be running")
     active = CLIENT.get_active_connections()
     adapter = choose_adapter(CLIENT)
     if adapter:


### PR DESCRIPTION
Hello,

I'm not sure if this is the best way to detect if the NetworkManager is running but it seems to be the more global way.

Also I don't raise an error but prefer to print a warning message to avoid to kill the program if NetworkManager is not running in the case that the detection is wrong.

I made this PR because I had an issue with my fresh Arch install. NetworkManager was not started but the script don't say anything about it. I feel that at least a small warning, while the information could be sometime incorrect, is better than none when you open the connection manager and it just close without any information. Now if their is a better way to do it or just none im open to listen.

thanks again for this script!