### PR TITLE
Make dmenu and pinentry formats configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,19 +75,23 @@ Manage NetworkManager connections with dmenu, [Rofi][1], [Bemenu][2],
 
 ### Config.ini values
 
-| Section              | Key                | Default   | Notes                                            |
-|----------------------|--------------------|-----------|--------------------------------------------------|
-| `[dmenu]`            | `compact`          | `False`   |                                                  |
-|                      | `dmenu_command`    | `dmenu`   | Command can include arguments                    |
-|                      | `list_saved`       | `False`   |                                                  |
-|                      | `pinentry`         | None      |                                                  |
-|                      | `rofi_highlight`   | `False`   |                                                  |
-|                      | `wifi_chars`       | None      | String of 4 unicode characters                   |
-| `[dmenu_passphrase]` | `obscure`          | `False`   |                                                  |
-|                      | `obscure_color`    | `#222222` | Only applicable to dmenu                         |
-| `[editor]`           | `gui_if_available` | `True`    |                                                  |
-|                      | `terminal`         | `xterm`   |                                                  |
-| `[nmdm]`             | `rescan_delay`     | `5`       | Adjust delay in re-opening nmdm following rescan |
+| Section              | Key                | Default                | Notes                                            |
+|----------------------|--------------------|------------------------|--------------------------------------------------|
+| `[dmenu]`            | `compact`          | `False`                |                                                  |
+|                      | `dmenu_command`    | `dmenu`                | Command can include arguments                    |
+|                      | `list_saved`       | `False`                |                                                  |
+|                      | `pinentry`         | None                   |                                                  |
+|                      | `rofi_highlight`   | `False`                |                                                  |
+|                      | `wifi_chars`       | None                   | String of 4 unicode characters                   |
+|                      | `wifi_icons`       | None                   | String of icon characters                        |
+|                      | `format`           | (depends on `compact`) | Python-style format string                       |
+| `[pinentry]`         | `description`      | `Get network password` |                                                  |
+|                      | `prompt`           | `Password:`            |                                                  |
+| `[dmenu_passphrase]` | `obscure`          | `False`                |                                                  |
+|                      | `obscure_color`    | `#222222`              | Only applicable to dmenu                         |
+| `[editor]`           | `gui_if_available` | `True`                 |                                                  |
+|                      | `terminal`         | `xterm`                |                                                  |
+| `[nmdm]`             | `rescan_delay`     | `5`                    | Adjust delay in re-opening nmdm following rescan |
 
 ## Usage
 

--- a/config.ini.example
+++ b/config.ini.example
@@ -17,6 +17,7 @@
 # # Available variables are:
 # #  * {name} - Access point name
 # #  * {sec} - Security type
+# #  * {signal} - Signal strength on a scale of 0-100
 # #  * {bars} - Bar-based display of signal strength (see wifi_chars)
 # #  * {icon} - Icon-based display of signal strength (see wifi_icons)
 # #  * {max_len_name} and {max_len_sec} are the maximum lengths of {name} / {sec}

--- a/config.ini.example
+++ b/config.ini.example
@@ -10,6 +10,17 @@
 # pinentry = <Pinentry command>  # (Default: None) e.g. `pinentry-gtk`
 # wifi_chars = <string of 4 unicode characters representing 1-4 bars strength>
 # wifi_chars = ▂▄▆█
+# wifi_icons = <characters representing signal strength as an icon>
+# wifi_icons = 󰤯󰤟󰤢󰤥󰤨
+# format = <Python style format string for the access point entries>
+# format = {name}  {sec}  {bars}
+# # Available variables are:
+# #  * {name} - Access point name
+# #  * {sec} - Security type
+# #  * {bars} - Bar-based display of signal strength (see wifi_chars)
+# #  * {icon} - Icon-based display of signal strength (see wifi_icons)
+# #  * {max_len_name} and {max_len_sec} are the maximum lengths of {name} / {sec}
+# #    respectively and may be useful for formatting.
 # list_saved = <True or False> # (Default: False) list saved connections
 
 [dmenu_passphrase]
@@ -18,6 +29,10 @@
 # # https://tools.suckless.org/dmenu/patches/password/
 # obscure = True
 # obscure_color = #222222
+
+[pinentry]
+# description = <Pinentry description> (Default: Get network password)
+# prompt = <Pinentry prompt> (Default: Password:)
 
 [editor]
 # terminal = <name of terminal program>

--- a/networkmanager_dmenu
+++ b/networkmanager_dmenu
@@ -378,6 +378,20 @@ def process_vpngsm(con, activate):
         CLIENT.deactivate_connection_async(con, None, deactivate_cb, con)
     LOOP.run()
 
+def strength_bars(signal_strength):
+    bars = NM.utils_wifi_strength_bars(signal_strength)
+    wifi_chars = CONF.get("dmenu", "wifi_chars", fallback=False)
+    if wifi_chars:
+        bars = "".join([wifi_chars[i] for i, j in enumerate(bars) if j == '*'])
+    return bars
+
+
+def strength_icon(signal_strength):
+    wifi_icons = CONF.get("dmenu", "wifi_icons", fallback=False)
+    if wifi_icons:
+        return wifi_icons[round(signal_strength / 100 * (len(wifi_icons) - 1))]
+    return ""
+
 
 def create_ap_actions(aps, active_ap, active_connection, adapter):  # noqa pylint: disable=too-many-locals,line-too-long
     """For each AP in a list, create the string and its attached function
@@ -393,17 +407,18 @@ def create_ap_actions(aps, active_ap, active_connection, adapter):  # noqa pylin
 
     ap_actions = []
 
+    if CONF.getboolean("dmenu", "compact", fallback=False):
+        format = CONF.get("dmenu", "format", fallback="{name}  {sec}  {bars}")
+    else:
+        format = CONF.get("dmenu", "format", "{name:<{max_len_name}s}  {sec:<{max_len_sec}s} {bars:>4}")
+
     for nm_ap, name, sec in zip(aps, names, secs):
-        bars = NM.utils_wifi_strength_bars(nm_ap.get_strength())
-        wifi_chars = CONF.get("dmenu", "wifi_chars", fallback=False)
-        if wifi_chars:
-            bars = "".join([wifi_chars[i] for i, j in enumerate(bars) if j == '*'])
         is_active = nm_ap.get_bssid() == active_ap_bssid
-        compact = CONF.getboolean("dmenu", "compact", fallback=False)
-        if compact:
-            action_name = f"{name}  {sec}  {bars}"
-        else:
-            action_name = f"{name:<{max_len_name}s}  {sec:<{max_len_sec}s} {bars:>4}"
+        signal_strength = nm_ap.get_strength()
+        bars = strength_bars(signal_strength)
+        icon = strength_icon(signal_strength)
+        action_name = format.format(name=name, sec=sec, bars=bars, icon=icon,
+                                    max_len_name=max_len_name, max_len_sec=max_len_sec)
         if is_active:
             ap_actions.append(Action(action_name, process_ap,
                                      [active_connection, True, adapter],
@@ -666,12 +681,14 @@ def get_passphrase():
     """
     pinentry = CONF.get("dmenu", "pinentry", fallback=None)
     if pinentry:
+        description = CONF.get("pinentry", "description", fallback="Get network password")
+        prompt = CONF.get("pinentry", "prompt", fallback="Password: ")
         pin = ""
         out = subprocess.run(pinentry,
                              capture_output=True,
                              check=False,
                              encoding=ENC,
-                             input='setdesc Get network password\ngetpin\n').stdout
+                             input=f"setdesc {description}\nsetprompt {prompt}\ngetpin\n").stdout
         if out:
             res = out.split("\n")[2]
             if res.startswith("D "):

--- a/networkmanager_dmenu
+++ b/networkmanager_dmenu
@@ -417,7 +417,7 @@ def create_ap_actions(aps, active_ap, active_connection, adapter):  # noqa pylin
         signal_strength = nm_ap.get_strength()
         bars = strength_bars(signal_strength)
         icon = strength_icon(signal_strength)
-        action_name = format.format(name=name, sec=sec, bars=bars, icon=icon,
+        action_name = format.format(name=name, sec=sec, signal=signal_strength, bars=bars, icon=icon,
                                     max_len_name=max_len_name, max_len_sec=max_len_sec)
         if is_active:
             ap_actions.append(Action(action_name, process_ap,

--- a/networkmanager_dmenu
+++ b/networkmanager_dmenu
@@ -410,7 +410,7 @@ def create_ap_actions(aps, active_ap, active_connection, adapter):  # noqa pylin
     if CONF.getboolean("dmenu", "compact", fallback=False):
         format = CONF.get("dmenu", "format", fallback="{name}  {sec}  {bars}")
     else:
-        format = CONF.get("dmenu", "format", "{name:<{max_len_name}s}  {sec:<{max_len_sec}s} {bars:>4}")
+        format = CONF.get("dmenu", "format", fallback="{name:<{max_len_name}s}  {sec:<{max_len_sec}s} {bars:>4}")
 
     for nm_ap, name, sec in zip(aps, names, secs):
         is_active = nm_ap.get_bssid() == active_ap_bssid


### PR DESCRIPTION
This PR allows the user to set the format of the dmenu entry as well as the description and prompt of the pin entry via the config. That should close #62. The dmenu format has placeholders for the name, the security type, and three different ways of showing signal strength: percentage, bars (current default), and icon. For example, the setting
```
format = {name} ({sec}) {signal}%% {icon}
```
produces the following output (with the appropriate setting of `wifi_icons`):

![20230612_01h07m25s_grim](https://github.com/firecat53/networkmanager-dmenu/assets/15610942/86f05baf-59f2-46bd-ab23-6343ad27a43c)

(yes, I'm at the airport right now...)