### PR TITLE
feat: customizable active prefix & highlighting style for wofi

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,10 @@ Manage NetworkManager connections with dmenu, [Rofi][1], [Bemenu][2],
 |                      | `list_saved`       | `False`                |                                                  |
 |                      | `pinentry`         | None                   |                                                  |
 |                      | `active_chars`     | ==                   | Prefix of active connection                      |
-|                      | `rofi_highlight`   | `False`                |                                                  |
+|                      | `highlight`        | `False`                | Only applicable to rofi / wofi                   |
+|                      | `highlight_fg`     | None                 | Only applicable to wofi                          |
+|                      | `highlight_bg`     | None                 | Only applicable to wofi                          |
+|                      | `highlight_bold`   | `True`                 | Only applicable to wofi                          |
 |                      | `wifi_chars`       | None                   | String of 4 unicode characters                   |
 |                      | `wifi_icons`       | None                   | String of icon characters                        |
 |                      | `format`           | (depends on `compact`) | Python-style format string                       |

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Manage NetworkManager connections with dmenu, [Rofi][1], [Bemenu][2],
    in the config file.
 8. (optional) ModemManager for WWAN support.
 9. (optional) notify-send for notifications (connected, disconnected, etc.)
+10. (optional) bluez package for bluetooth control
 
 ## Configuration 
 
@@ -63,13 +64,16 @@ Manage NetworkManager connections with dmenu, [Rofi][1], [Bemenu][2],
     1. Set [PolicyKit permissions][5]. The script is usable for connecting to
        pre-existing connections without setting these, but you won't be able to
        enable/disable networking or add new connections.
-    2. For bluetooth control, the user needs to have access to `/dev/rfkill`. On
-       some distros (e.g. Archlinux), `/dev/rfkill` belongs to a group such as
-       `rfkill`. In this case, ensure $USER belongs to that group. For other
-       distros (e.g. Fedora), you can use udev to ensure `/dev/rfkill` belongs
-       to a group. For example, create `/etc/udev/rules.d/10-rfkill.rules`:
-       
-                KERNEL=="rfkill", GROUP="wheel", MODE="0664"
+- For bluetooth control, there are two options:
+    1. If bluez is installed and the bluetooth service is running, no further
+       action is needed.
+    2. If not, the user needs to have access to `/dev/rfkill`. On some distros
+       (e.g. Archlinux), `/dev/rfkill` belongs to a group such as `rfkill`. In
+       this case, ensure $USER belongs to that group. For other distros (e.g.
+       Fedora), you can use udev to ensure `/dev/rfkill` belongs to a group. For
+       example, create `/etc/udev/rules.d/10-rfkill.rules`:
+
+               KERNEL=="rfkill", GROUP="wheel", MODE="0664"
     
        and then ensure $USER belongs to the `wheel` group.
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Manage NetworkManager connections with dmenu, [Rofi][1], [Bemenu][2],
 |                      | `dmenu_command`    | `dmenu`                | Command can include arguments                    |
 |                      | `list_saved`       | `False`                |                                                  |
 |                      | `pinentry`         | None                   |                                                  |
+|                      | `active_chars`     | ==                   | Prefix of active connection                      |
 |                      | `rofi_highlight`   | `False`                |                                                  |
 |                      | `wifi_chars`       | None                   | String of 4 unicode characters                   |
 |                      | `wifi_icons`       | None                   | String of icon characters                        |

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 Manage NetworkManager connections with dmenu, [Rofi][1], [Bemenu][2],
 [Wofi][7] or [fuzzel][8] instead of nm-applet
 
+**NOTE**
+
+> PR #124 changes `rofi_highlight` to `highlight` in `config.ini`.
+
 ## Features
 
 - Connect to existing NetworkManager wifi or wired connections
@@ -85,10 +89,10 @@ Manage NetworkManager connections with dmenu, [Rofi][1], [Bemenu][2],
 |                      | `dmenu_command`    | `dmenu`                | Command can include arguments                    |
 |                      | `list_saved`       | `False`                |                                                  |
 |                      | `pinentry`         | None                   |                                                  |
-|                      | `active_chars`     | ==                   | Prefix of active connection                      |
+|                      | `active_chars`     | ==                     | Prefix of active connection                      |
 |                      | `highlight`        | `False`                | Only applicable to rofi / wofi                   |
-|                      | `highlight_fg`     | None                 | Only applicable to wofi                          |
-|                      | `highlight_bg`     | None                 | Only applicable to wofi                          |
+|                      | `highlight_fg`     | None                   | Only applicable to wofi                          |
+|                      | `highlight_bg`     | None                   | Only applicable to wofi                          |
 |                      | `highlight_bold`   | `True`                 | Only applicable to wofi                          |
 |                      | `wifi_chars`       | None                   | String of 4 unicode characters                   |
 |                      | `wifi_icons`       | None                   | String of icon characters                        |

--- a/config.ini.example
+++ b/config.ini.example
@@ -6,7 +6,10 @@
 # # `dmenu_command = dmenu -i -l 25 -b -nb #909090 -nf #303030`
 # # `dmenu_command = fuzzel --dmenu`
 # active_chars = ==
-# rofi_highlight = <True or False> # (Default: False) use rofi highlighting instead of active_chars
+# highlight = <True or False> # (Default: False) use highlighting instead of active_chars (only applicable to Rofi / Wofi)
+# highlight_fg = <Color> # (Default: None) foreground color of active connection (only applicable to Wofi)
+# highlight_bg = <Color> # (Default: None) background color of active connection (only applicable to Wofi)
+# highlight_bold = <True or False> # (Default: True) make active connection bold (only applicable to Wofi)
 # compact = <True or False> # (Default: False). Remove extra spacing from display
 # pinentry = <Pinentry command>  # (Default: None) e.g. `pinentry-gtk`
 # wifi_chars = <string of 4 unicode characters representing 1-4 bars strength>

--- a/config.ini.example
+++ b/config.ini.example
@@ -5,7 +5,8 @@
 # # `dmenu_command = rofi -dmenu -width 30 -i`
 # # `dmenu_command = dmenu -i -l 25 -b -nb #909090 -nf #303030`
 # # `dmenu_command = fuzzel --dmenu`
-# rofi_highlight = <True or False> # (Default: False) use rofi highlighting instead of '=='
+# active_chars = ==
+# rofi_highlight = <True or False> # (Default: False) use rofi highlighting instead of active_chars
 # compact = <True or False> # (Default: False). Remove extra spacing from display
 # pinentry = <Pinentry command>  # (Default: None) e.g. `pinentry-gtk`
 # wifi_chars = <string of 4 unicode characters representing 1-4 bars strength>

--- a/config.ini.example
+++ b/config.ini.example
@@ -5,6 +5,7 @@
 # # `dmenu_command = rofi -dmenu -width 30 -i`
 # # `dmenu_command = dmenu -i -l 25 -b -nb #909090 -nf #303030`
 # # `dmenu_command = fuzzel --dmenu`
+# # `dmenu_command = wofi --dmenu`
 # active_chars = ==
 # highlight = <True or False> # (Default: False) use highlighting instead of active_chars (only applicable to Rofi / Wofi)
 # highlight_fg = <Color> # (Default: None) foreground color of active connection (only applicable to Wofi)

--- a/networkmanager_dmenu
+++ b/networkmanager_dmenu
@@ -37,6 +37,8 @@ ENC = locale.getpreferredencoding()
 CONF = configparser.ConfigParser()
 CONF.read(expanduser("~/.config/networkmanager-dmenu/config.ini"))
 
+CMD_BASE = ""
+
 
 def cli_args():
     """ Don't override dmenu_cmd function arguments with CLI args. Removes -l
@@ -102,10 +104,16 @@ def dmenu_cmd(num_lines, prompt="Networks", active_lines=None):
     cmd_base = basename(command[0])
     command.extend(cli_args())
     command.extend(commands.get(cmd_base, []))
-    # Rofi Highlighting
-    rofi_highlight = CONF.getboolean('dmenu', 'rofi_highlight', fallback=False)
-    if rofi_highlight is True and cmd_base == "rofi" and active_lines:
-        command.extend(["-a", ",".join([str(num) for num in active_lines])])
+    # Highlighting
+    highlight = CONF.getboolean('dmenu', 'highlight', fallback=False)
+    if highlight is True:
+        # Rofi
+        if cmd_base == "rofi" and active_lines:
+            command.extend(["-a", ",".join([str(num) for num in active_lines])])
+        # Wofi
+        if cmd_base == "wofi" and active_lines:
+            # add '-q' to prevent tag name and properties of pango markup from searchable
+            command.extend(["-m", "-q"])
     # Passphrase prompts
     obscure = CONF.getboolean('dmenu_passphrase', 'obscure', fallback=False)
     if prompt == "Passphrase" and obscure is True:
@@ -550,16 +558,37 @@ def combine_actions(eths, aps, vpns, wgs, gsms, blues, wwan, others, saved):
     return all_actions
 
 
+def get_wofi_highlight_markup(action):
+    highlight_fg = CONF.get('dmenu', 'highlight_fg', fallback=None)
+    highlight_bg = CONF.get('dmenu', 'highlight_bg', fallback=None)
+    highlight_bold = CONF.getboolean('dmenu', 'highlight_bold', fallback=True)
+
+    style = ""
+    if highlight_fg:
+        style += f'foreground="{highlight_fg}" '
+    if highlight_bg:
+        style += f'background="{highlight_bg}" '
+    if highlight_bold:
+        style += f'weight="bold" '
+
+    return f"<span {style}>" + str(action) + "</span>"
+
+
 def get_selection(all_actions):
     """Spawn dmenu for selection and execute the associated action."""
-    active_chars = CONF.get('dmenu', 'active_chars', fallback='==')
-    rofi_highlight = CONF.getboolean('dmenu', 'rofi_highlight', fallback=False)
+    command = shlex.split(CONF.get("dmenu", "dmenu_command", fallback="dmenu"))
+    cmd_base = basename(command[0])
+    active_chars = CONF.get("dmenu", "active_chars", fallback="==")
+    highlight = CONF.getboolean("dmenu", "highlight", fallback=False)
     inp = []
 
-    if rofi_highlight is True:
+    if highlight is True and cmd_base == "rofi":
         inp = [str(action) for action in all_actions]
+    elif highlight is True and cmd_base == "wofi":
+        inp = [get_wofi_highlight_markup(action) if action.is_active else str(action)
+               for action in all_actions]
     else:
-        inp = [(active_chars if action.is_active else ' ' * len(active_chars)) + ' ' + str(action)
+        inp = [(active_chars if action.is_active else " " * len(active_chars)) + " " + str(action)
                for action in all_actions]
     active_lines = [index for index, action in enumerate(all_actions)
                     if action.is_active]
@@ -575,14 +604,18 @@ def get_selection(all_actions):
     if not sel.rstrip():
         sys.exit()
 
-    if rofi_highlight is False:
+    if highlight is True and cmd_base == "rofi":
+        action = [i for i in all_actions if str(i).strip() == sel.strip()]
+    elif highlight is True and cmd_base == "wofi":
+        action = [i for i in all_actions
+                  if str(i).strip() == sel.strip() or
+                     get_wofi_highlight_markup(i) == sel.strip()]
+    else:
         action = [i for i in all_actions
                   if ((str(i).strip() == str(sel.strip())
                        and not i.is_active) or
-                      (active_chars + ' ' + str(i) == str(sel.rstrip('\n'))
+                      (active_chars + " " + str(i) == str(sel.rstrip('\n'))
                        and i.is_active))]
-    else:
-        action = [i for i in all_actions if str(i).strip() == sel.strip()]
     if len(action) != 1:
         raise ValueError(f"Selection was ambiguous: '{str(sel.strip())}'")
     return action[0]

--- a/networkmanager_dmenu
+++ b/networkmanager_dmenu
@@ -150,10 +150,21 @@ def is_installed(cmd):
 
 
 def bluetooth_get_enabled():
-    """Check if bluetooth is enabled via rfkill.
+    """Check if bluetooth is enabled. Try bluetoothctl first, then rfkill.
 
     Returns None if no bluetooth device was found.
     """
+    if is_installed('bluetoothctl'):
+        # Times out in 2 seconds, otherwise bluetoothctl will hang if bluetooth
+        # service isn't running.
+        try:
+            res = subprocess.run(['bluetoothctl', 'show'],
+                                 timeout=2,
+                                 capture_output=True,
+                                 text=True)
+            return "Powered: yes" in res.stdout
+        except subprocess.TimeoutExpired:
+            pass
     # See https://www.kernel.org/doc/Documentation/ABI/stable/sysfs-class-rfkill
     for path in pathlib.Path('/sys/class/rfkill/').glob('rfkill*'):
         if (path / 'type').read_text().strip() == 'bluetooth':
@@ -627,6 +638,9 @@ def toggle_wwan(enable):
 def toggle_bluetooth(enable):
     """Enable/disable Bluetooth
 
+    Try bluetoothctl first, then drop to rfkill if it's not installed or
+    bluetooth service isn't running.
+
     Args: enable - boolean
 
     References:
@@ -635,6 +649,26 @@ def toggle_bluetooth(enable):
     https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/include/uapi/linux/rfkill.h?h=v5.8.9
 
     """
+    if is_installed('bluetoothctl'):
+        # Times out in 2 seconds, otherwise bluetoothctl will hang if bluetooth
+        # service isn't running.
+        try:
+            res = subprocess.run(['bluetoothctl', 'power', 'on' if enable is True else 'off'],
+                                 timeout=2,
+                                 capture_output=True)
+        except subprocess.TimeoutExpired:
+            pass
+        try:
+            res = subprocess.run(['bluetoothctl', 'show'],
+                                 timeout=2,
+                                 capture_output=True,
+                                 text=True)
+            if "Powered: yes" in res.stdout:
+                notify("Bluetooth enabled")
+                return
+        except subprocess.TimeoutExpired:
+            pass
+    # Now try using rfkill
     type_bluetooth = 2
     op_change_all = 3
     idx = 0

--- a/networkmanager_dmenu
+++ b/networkmanager_dmenu
@@ -552,13 +552,14 @@ def combine_actions(eths, aps, vpns, wgs, gsms, blues, wwan, others, saved):
 
 def get_selection(all_actions):
     """Spawn dmenu for selection and execute the associated action."""
+    active_chars = CONF.get('dmenu', 'active_chars', fallback='==')
     rofi_highlight = CONF.getboolean('dmenu', 'rofi_highlight', fallback=False)
     inp = []
 
     if rofi_highlight is True:
         inp = [str(action) for action in all_actions]
     else:
-        inp = [('== ' if action.is_active else '   ') + str(action)
+        inp = [(active_chars if action.is_active else ' ' * len(active_chars)) + ' ' + str(action)
                for action in all_actions]
     active_lines = [index for index, action in enumerate(all_actions)
                     if action.is_active]
@@ -578,7 +579,7 @@ def get_selection(all_actions):
         action = [i for i in all_actions
                   if ((str(i).strip() == str(sel.strip())
                        and not i.is_active) or
-                      ('== ' + str(i) == str(sel.rstrip('\n'))
+                      (active_chars + ' ' + str(i) == str(sel.rstrip('\n'))
                        and i.is_active))]
     else:
         action = [i for i in all_actions if str(i).strip() == sel.strip()]


### PR DESCRIPTION
I added 2 features.

1. customizable active prefix
```ini
[dmenu]
active_chars = v  # (default: ==)
```

![image](https://github.com/firecat53/networkmanager-dmenu/assets/24734750/81905eff-da37-4ba8-b720-c1d90aba5163)

2. highlight active connection and customizable style for wofi
I don't use other menus, and don't know whether it's possible there, so I only support wofi.

> **Warning**
> There's a breaking change. I renamed `rofi_highlight` to `highlight`.
> In my opinion, it's better than introducing another `wofi_highlight` field.

```ini
[dmenu]
highlight = True
```

![image](https://github.com/firecat53/networkmanager-dmenu/assets/24734750/0570dd04-292c-4260-85e9-43cfa2eb6cba)
> Default highlighting style is bold text.

The followings are fields for the highlighting style.

```ini
[dmenu]
highlight_fg = #f2b468
highlight_bg = black
highlight_bold = False
```

![image](https://github.com/firecat53/networkmanager-dmenu/assets/24734750/14000237-5027-4137-a185-2382780a9240)

Please tell me what to do if I missed something. Thank you!