### PR TITLE
Check if bluetoothd is running before executing bluetoothctl

### DIFF
--- a/networkmanager_dmenu
+++ b/networkmanager_dmenu
@@ -155,12 +155,21 @@ def is_installed(cmd):
     return which(cmd) is not None
 
 
+def is_running(cmd):
+    try:
+        subprocess.check_output(["pidof", cmd])
+    except subprocess.CalledProcessError:
+        return False
+    else:
+        return True
+
+
 def bluetooth_get_enabled():
     """Check if bluetooth is enabled. Try bluetoothctl first, then rfkill.
 
     Returns None if no bluetooth device was found.
     """
-    if is_installed('bluetoothctl'):
+    if is_installed('bluetoothctl') and is_running('bluetoothd'):
         # Times out in 2 seconds, otherwise bluetoothctl will hang if bluetooth
         # service isn't running.
         try:
@@ -691,7 +700,7 @@ def toggle_bluetooth(enable):
     https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/include/uapi/linux/rfkill.h?h=v5.8.9
 
     """
-    if is_installed('bluetoothctl'):
+    if is_installed('bluetoothctl') and is_running('bluetoothd'):
         # Times out in 2 seconds, otherwise bluetoothctl will hang if bluetooth
         # service isn't running.
         try:


### PR DESCRIPTION
This adds an extra check before calling `bluetoothctl`, making sure that `bluetoothd` is running so the command doesn't hang.

Maybe there are better ways to perform this check, so let me know if the code could be improved (actually, this is my first pull request ever, so let me know if I'm doing something wrong).

Fixes #131 