### PR TITLE
add ability to select gui

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Manage NetworkManager connections with dmenu, [Rofi][1], [Bemenu][2],
 | `[dmenu_passphrase]` | `obscure`          | `False`                |                                                  |
 |                      | `obscure_color`    | `#222222`              | Only applicable to dmenu                         |
 | `[editor]`           | `gui_if_available` | `True`                 |                                                  |
+|                      | `gui`              | `nm-connection-editor` |                                                  |
 |                      | `terminal`         | `xterm`                |                                                  |
 | `[nmdm]`             | `rescan_delay`     | `5`                    | Adjust delay in re-opening nmdm following rescan |
 

--- a/config.ini.example
+++ b/config.ini.example
@@ -43,6 +43,7 @@
 [editor]
 # terminal = <name of terminal program>
 # gui_if_available = <True or False> (Default: True)
+# gui = <name of gui editor> (Default: nm-connection-editor)
 
 [nmdm]
 # rescan_delay = <seconds>  # (seconds to wait after a wifi rescan before redisplaying the results)

--- a/networkmanager_dmenu
+++ b/networkmanager_dmenu
@@ -746,7 +746,7 @@ def launch_connection_editor():
     """
     terminal = CONF.get("editor", "terminal", fallback="xterm")
     gui_if_available = CONF.getboolean("editor", "gui_if_available", fallback=True)
-    gui = CONF.get("editor", "gui", fallback="gnome-control-center")
+    gui = CONF.get("editor", "gui", fallback="nm-connection-editor")
     if gui_if_available is True:
         if is_installed(gui):
             subprocess.run(gui, check=False)

--- a/networkmanager_dmenu
+++ b/networkmanager_dmenu
@@ -746,12 +746,11 @@ def launch_connection_editor():
     """
     terminal = CONF.get("editor", "terminal", fallback="xterm")
     gui_if_available = CONF.getboolean("editor", "gui_if_available", fallback=True)
-    guis = ["gnome-control-center", "nm-connection-editor"]
+    gui = CONF.get("editor", "gui", fallback="gnome-control-center")
     if gui_if_available is True:
-        for gui in guis:
-            if is_installed(gui):
-                subprocess.run(gui, check=False)
-                return
+        if is_installed(gui):
+            subprocess.run(gui, check=False)
+            return
     if is_installed("nmtui"):
         subprocess.run([terminal, "-e", "nmtui"], check=False)
         return


### PR DESCRIPTION
If gnome is installed, but you are not in a gnome environment, gnome-control-center is still used. However, it will not work outside of gnome shells.

This PR adds the ability to select which GUI editor to use, the fallback value is still gnome-control-center.

However, this will break for people who do not have gnome installed as it will not fall through to nm-connection-editor.

Configuration example is as follows,

```
[editor]
gui = nm-connection-editor
```