### PR TITLE
Add --dmenu option to wofi invocation

### DIFF
--- a/networkmanager_dmenu
+++ b/networkmanager_dmenu
@@ -96,7 +96,7 @@ def dmenu_cmd(num_lines, prompt="Networks", active_lines=None):
     commands = {"dmenu": ["-p", str(prompt)],
                 "rofi": ["-dmenu", "-p", str(prompt)],
                 "bemenu": ["-p", str(prompt)],
-                "wofi": ["-p", str(prompt)],
+                "wofi": ["--dmenu", "-p", str(prompt)],
                 "fuzzel": ["-p", str(prompt), "--log-level", "none"]}
     command = shlex.split(CONF.get('dmenu', 'dmenu_command', fallback="dmenu"))
     cmd_base = basename(command[0])


### PR DESCRIPTION
On Wayland, with `wofi`, the script fails with a cryptic error:

```
(process:100791): GLib-GObject-CRITICAL **: 18:24:27.791: g_object_get_qdata: assertion 'G_IS_OBJECT (object)' failed

(process:100791): GLib-GObject-CRITICAL **: 18:24:27.791: g_object_set_qdata_full: assertion 'G_IS_OBJECT (object)' failed

(process:100791): GLib-GObject-CRITICAL **: 18:24:27.791: g_object_set_qdata_full: assertion 'G_IS_OBJECT (object)' failed

(process:100791): GLib-GObject-CRITICAL **: 18:24:27.791: g_object_unref: assertion 'G_IS_OBJECT (object)' failed
```

Turns out it is due to the failure in launching `wofi`, as it requires the `--dmenu` option to operate in `dmenu` mode.

This PR adds the same.

PS: Please let me know if you'd like me to create an issue first!