### PR TITLE
Allow for terminal arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Manage NetworkManager connections with dmenu, [Rofi][1], [Bemenu][2],
 |                      | `obscure_color`    | `#222222`              | Only applicable to dmenu                         |
 | `[editor]`           | `gui_if_available` | `True`                 |                                                  |
 |                      | `gui`              | `nm-connection-editor` |                                                  |
-|                      | `terminal`         | `xterm`                |                                                  |
+|                      | `terminal`         | `xterm`                | Can include terminal arguments                   |
 | `[nmdm]`             | `rescan_delay`     | `5`                    | Adjust delay in re-opening nmdm following rescan |
 
 ## Usage

--- a/config.ini.example
+++ b/config.ini.example
@@ -41,7 +41,7 @@
 # prompt = <Pinentry prompt> (Default: Password:)
 
 [editor]
-# terminal = <name of terminal program>
+# terminal = <name of terminal program> <arguments>
 # gui_if_available = <True or False> (Default: True)
 # gui = <name of gui editor> (Default: nm-connection-editor)
 

--- a/networkmanager_dmenu
+++ b/networkmanager_dmenu
@@ -744,7 +744,7 @@ def launch_connection_editor():
     """Launch nmtui or the gui nm-connection-editor
 
     """
-    terminal = CONF.get("editor", "terminal", fallback="xterm")
+    terminal = shlex.split(CONF.get("editor", "terminal", fallback="xterm"))
     gui_if_available = CONF.getboolean("editor", "gui_if_available", fallback=True)
     gui = CONF.get("editor", "gui", fallback="nm-connection-editor")
     if gui_if_available is True:
@@ -752,7 +752,7 @@ def launch_connection_editor():
             subprocess.run(gui, check=False)
             return
     if is_installed("nmtui"):
-        subprocess.run([terminal, "-e", "nmtui"], check=False)
+        subprocess.run(terminal + ["-e", "nmtui"], check=False)
         return
     notify("No network connection editor installed", urgency="critical")
 


### PR DESCRIPTION
Small change to launch connection editor function.
Allow for adding extra arguments to the terminal in the config. e.g.
`[editor]
terminal = foot --app-id floating`