### PR TITLE
README: Replace networkmanager-applet with nm-connection-editor, add a note, regarding non-Arch distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,11 @@ Manage NetworkManager connections with dmenu, [Rofi][1], [Bemenu][2],
 4. Python gobject (PyGObject, python-gobject, etc.)
 5. (Debian/Ubuntu based distros) libnm0 (libnm-util-dev on older distributions)
    and gir1.2-nm-1.0 (you have to explicitly install the latter on Debian Sid)
-6. (optional) The network-manager-applet package (in order to launch the GUI
-   connection editor, if desired. The nm-applet does _not_ need to be started.)
+6. (optional) The nm-connection-editor package (in order to launch the GUI
+   connection editor, if desired.).
+   
+   <b>Note:</b> On some distros, the nm-connection-editor might not exist as a separate package and may instead be part of the networkmanager-applet. In this case, the applet does not need to be started in order to use the GUI connection editor.
+
 7. (optional) Pinentry. Make sure to set which flavor of pinentry command to use
    in the config file.
 8. (optional) ModemManager for WWAN support.


### PR DESCRIPTION
The connections editor GUI is a part of `nm-connection-editor package`, which doesn't need `networkmanager-applet` in order to function, despite being a hard dependency for it. Also, added a note for distros, that don't separate these two packages.

Additionally, I suggest editing the [PKGBUILD](https://aur.archlinux.org/packages/networkmanager-dmenu-git) accordingly.