### PR TITLE
Remove a space after the title in the .desktop

### DIFF
--- a/networkmanager_dmenu.desktop
+++ b/networkmanager_dmenu.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Categories=Settings;Network;
-Name=NetworkManager Dmenu 
+Name=NetworkManager Dmenu
 GenericName=Networkmanager Settings
 Exec=networkmanager_dmenu
 Icon=nm-device-wireless


### PR DESCRIPTION
Noticed it because there was a space between the title and the description in the dmenu entry.
I don't know how you manage the branches, feel free to edit the PR to merge into the correct one.