### PR TITLE
fix: correct password options for wmenu

### DIFF
--- a/networkmanager_dmenu
+++ b/networkmanager_dmenu
@@ -393,7 +393,7 @@ def dmenu_cmd(prompt, active_lines=None):
             "rofi": ["-password"],
             "tofi": ["--hide-input=true", "--hidden-character=*"],
             "walker": ["-y", "-n"],
-            "wmenu": dmenu_pass(cmd_base, obscure_color),
+            "wmenu": ["-P"],
             "wofi": ["-P"],
         }
         command.extend(pass_prompts.get(cmd_base, []))


### PR DESCRIPTION
`dmenu_pass` function rejects all command exept `dmenu`. But it is called for `wmenu` in line 396, which makes `pass_prompts` `None`.

This is the error message:

```
Traceback (most recent call last):
  File "/home/hang/projects/networkmanager-dmenu/./networkmanager_dmenu", line 1485, in <module>
    main()
    ~~~~^^
  File "/home/hang/projects/networkmanager-dmenu/./networkmanager_dmenu", line 1481, in main
    run()
    ~~~^^
  File "/home/hang/projects/networkmanager-dmenu/./networkmanager_dmenu", line 1472, in run
    sel()
    ~~~^^
  File "/home/hang/projects/networkmanager-dmenu/./networkmanager_dmenu", line 598, in __call__
    self.func(*self.args)
    ~~~~~~~~~^^^^^^^^^^^^
  File "/home/hang/projects/networkmanager-dmenu/./networkmanager_dmenu", line 652, in process_ap
    password = get_passphrase()
  File "/home/hang/projects/networkmanager-dmenu/./networkmanager_dmenu", line 1185, in get_passphrase
    dmenu_cmd("Passphrase"),
    ~~~~~~~~~^^^^^^^^^^^^^^
  File "/home/hang/projects/networkmanager-dmenu/./networkmanager_dmenu", line 399, in dmenu_cmd
    command.extend(pass_prompts.get(cmd_base, []))
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'NoneType' object is not iterable
```

Since `wmenu` has native support for `-P`([see here](https://man.archlinux.org/man/wmenu.1.en)). I directly change the option to `-P`.