### PR TITLE
Fixing walker command arguments

### DIFF
--- a/networkmanager_dmenu
+++ b/networkmanager_dmenu
@@ -361,7 +361,7 @@ def dmenu_cmd(prompt, active_lines=None):
         "fuzzel": ["--dmenu", "--placeholder", str(prompt)],
         "rofi": ["-dmenu", "-p", str(prompt)],
         "tofi": ["--require-match=false", f"--prompt-text={str(prompt)}: "],
-        "walker": ["-d", "-p", str(prompt), "-k", "-n", "-f"],
+        "walker": ["-d", "-p", str(prompt), "-k", "-n"],
         "wmenu": ["-p", str(prompt)],
         "wofi": ["--dmenu", "-p", str(prompt)],
     }

--- a/networkmanager_dmenu
+++ b/networkmanager_dmenu
@@ -361,7 +361,7 @@ def dmenu_cmd(prompt, active_lines=None):
         "fuzzel": ["--dmenu", "--placeholder", str(prompt)],
         "rofi": ["-dmenu", "-p", str(prompt)],
         "tofi": ["--require-match=false", f"--prompt-text={str(prompt)}: "],
-        "walker": ["-d", "-p", str(prompt), "-k", "-n"],
+        "walker": ["-d", "-p", str(prompt), "-k"],
         "wmenu": ["-p", str(prompt)],
         "wofi": ["--dmenu", "-p", str(prompt)],
     }
@@ -392,7 +392,7 @@ def dmenu_cmd(prompt, active_lines=None):
             "fuzzel": ["--password"],
             "rofi": ["-password"],
             "tofi": ["--hide-input=true", "--hidden-character=*"],
-            "walker": ["-y", "-n"],
+            "walker": ["-y", "-I"],
             "wmenu": ["-P"],
             "wofi": ["-P"],
         }


### PR DESCRIPTION
`-f` argument does not exist in current walker version (cf https://benz.gitbook.io/walker/dmenu) and was preventing walker to open

removing the `-f` makes walker to open as intended.