### PR TITLE
Fix Bluetooth state not updating

### DIFF
--- a/networkmanager_dmenu
+++ b/networkmanager_dmenu
@@ -466,7 +466,8 @@ def bluetooth_get_enabled():
         # service isn't running.
         try:
             res = subprocess.run(
-                ["bluetoothctl", "show"],
+                ["bluetoothctl <<< show"],
+                shell=True,
                 timeout=2,
                 capture_output=True,
                 text=True,


### PR DESCRIPTION
https://github.com/bluez/bluez/issues/1896 causes `bluetoothctl show` to not have any output. I've patched here to make it run `bluetoothctl <<< show` through a shell instead, so that output works